### PR TITLE
Bugfix for the error messages.

### DIFF
--- a/src/main/java/io/cdap/plugin/ariba/source/AribaServices.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/AribaServices.java
@@ -629,7 +629,9 @@ public class AribaServices {
    */
   public Response executeRequest(Request req) throws AribaException, InterruptedException, IOException {
     OkHttpClient enhancedOkHttpClient = getConfiguredClient().build();
-    Response response = enhancedOkHttpClient.newCall(req).execute();
+    Response response = null;
+    try {
+      response = enhancedOkHttpClient.newCall(req).execute();
     if (response.code() != HttpURLConnection.HTTP_OK && AribaUtil.isNullOrEmpty(response.message())) {
       AribaResponseContainer responseContainer = aribaResponse(response);
       InputStream responseStream = responseContainer.getResponseBody();
@@ -643,11 +645,16 @@ public class AribaServices {
       checkAndThrowException(response);
       return response;
     } else {
-      return enhancedOkHttpClient.newCall(req).execute();
+      response = enhancedOkHttpClient.newCall(req).execute();
     }
+  } catch (IOException e) {
+    throw new IOException("Endpoint is incorrect. Unable to validate the source with the provided.", e);
   }
 
-  /**
+    return response;
+}
+
+/**
    * @param jobId Ariba Job Id
    * @return JsonNode
    */

--- a/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnector.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnector.java
@@ -101,7 +101,9 @@ public class AribaConnector implements DirectConnector {
   public void test(ConnectorContext connectorContext) throws ValidationException {
     FailureCollector collector = connectorContext.getFailureCollector();
     config.validateCredentials(collector);
+    collector.getOrThrowException();
     config.validateToken(collector);
+    collector.getOrThrowException();
   }
 
   @Override

--- a/src/test/java/io/cdap/plugin/ariba/source/metadata/proto/PropertiesTest.java
+++ b/src/test/java/io/cdap/plugin/ariba/source/metadata/proto/PropertiesTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.etl.api.connector.ConnectorSpec;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
 import io.cdap.cdap.etl.api.connector.PluginSpec;
 import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.mock.common.MockConnectorConfigurer;
 import io.cdap.cdap.etl.mock.common.MockConnectorContext;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
@@ -307,8 +308,12 @@ public class PropertiesTest {
 
   private void testTest(AribaConnector connector) {
     ConnectorContext context = new MockConnectorContext(new MockConnectorConfigurer());
-    connector.test(context);
-    Assert.assertEquals(1, context.getFailureCollector().getValidationFailures().size());
+    try {
+      connector.test(context);
+      Assert.fail("Exception will not thrown if credentials are correct");
+    } catch (ValidationException e) {
+      Assert.assertEquals(1, context.getFailureCollector().getValidationFailures().size());
+    }
   }
 
   @Test


### PR DESCRIPTION
**Bug:** 
Expected behaviour : Valid error messages should be displayed for incorrect and invalid API Endpoints
Actual behaviour : Invalid messages are displayed in connection manager and plugin UI for the endpoints.

**Fix:** 
Changed the error message.

