### PR TITLE
[cherry-pick][PLUGIN-1754] Add Retry with dev.failsafe 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <guava.version>27.0.1-jre</guava.version>
     <gcs.client.version>2.6.0</gcs.client.version>
     <commons-codec.version>1.10</commons-codec.version>
+    <failsafe.version>3.3.2</failsafe.version>
   </properties>
 
   <repositories>
@@ -60,6 +61,11 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>dev.failsafe</groupId>
+      <artifactId>failsafe</artifactId>
+      <version>${failsafe.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/src/main/java/io/cdap/plugin/ariba/source/AribaBatchSource.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/AribaBatchSource.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.plugin.ariba.source.config.AribaPluginConfig;
-import io.cdap.plugin.ariba.source.connector.AribaConnector;
 import io.cdap.plugin.ariba.source.exception.AribaException;
 import io.cdap.plugin.ariba.source.util.AribaUtil;
 import io.cdap.plugin.ariba.source.util.ResourceConstants;
@@ -69,7 +68,12 @@ public class AribaBatchSource extends BatchSource<NullWritable, StructuredRecord
 
   public AribaBatchSource(AribaPluginConfig pluginConfig) {
     this.pluginConfig = pluginConfig;
-    aribaServices = new AribaServices(pluginConfig.getConnection());
+    aribaServices = new AribaServices(pluginConfig.getConnection(),
+      pluginConfig.getMaxRetryCount(),
+      pluginConfig.getInitialRetryDuration(),
+      pluginConfig.getMaxRetryDuration(),
+      pluginConfig.getRetryMultiplier(),
+      false);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/ariba/source/AribaInputFormat.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/AribaInputFormat.java
@@ -54,7 +54,12 @@ public class AribaInputFormat extends InputFormat<NullWritable, StructuredRecord
   @Override
   public List<InputSplit> getSplits(JobContext jobContext) throws IOException {
     AribaPluginConfig pluginConfig = getPluginConfig(jobContext);
-    AribaServices aribaServices = new AribaServices(pluginConfig.getConnection());
+    AribaServices aribaServices = new AribaServices(pluginConfig.getConnection(),
+      pluginConfig.getMaxRetryCount(),
+      pluginConfig.getInitialRetryDuration(),
+      pluginConfig.getMaxRetryDuration(),
+      pluginConfig.getRetryMultiplier(),
+      true);
     boolean previewEnabled = Boolean.parseBoolean(jobContext.getConfiguration().
                                                     get(ResourceConstants.IS_PREVIEW_ENABLED));
 
@@ -66,7 +71,12 @@ public class AribaInputFormat extends InputFormat<NullWritable, StructuredRecord
   public RecordReader<NullWritable, StructuredRecord> createRecordReader(InputSplit inputSplit, TaskAttemptContext
     taskAttemptContext) throws IOException {
     AribaPluginConfig pluginConfig = getPluginConfig(taskAttemptContext);
-    AribaServices aribaServices = new AribaServices(pluginConfig.getConnection());
+    AribaServices aribaServices = new AribaServices(pluginConfig.getConnection(),
+      pluginConfig.getMaxRetryCount(),
+      pluginConfig.getInitialRetryDuration(),
+      pluginConfig.getMaxRetryDuration(),
+      pluginConfig.getRetryMultiplier(),
+      true);
     Schema outputSchema = Schema.parseJson(taskAttemptContext.getConfiguration().get(ResourceConstants.OUTPUT_SCHEMA));
     return new AribaRecordReader(aribaServices, outputSchema, pluginConfig);
   }

--- a/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnector.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnector.java
@@ -88,6 +88,7 @@ public class AribaConnector implements DirectConnector {
   private static final String TOKEN = "PageToken";
   private static final Gson GSON = new Gson();
   private final AribaConnectorConfig config;
+  private final AribaServices aribaServices;
   private static final String AUTHORIZATION = "Authorization";
   private String accessToken;
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -95,6 +96,12 @@ public class AribaConnector implements DirectConnector {
 
   public AribaConnector(AribaConnectorConfig config) {
     this.config = config;
+    aribaServices = new AribaServices(config,
+      AribaPluginConfig.DEFAULT_MAX_RETRY_COUNT,
+      AribaPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
+      AribaPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS,
+      AribaPluginConfig.DEFAULT_RETRY_MULTIPLIER,
+      false);
   }
 
   @Override
@@ -126,7 +133,6 @@ public class AribaConnector implements DirectConnector {
   @Override
   public ConnectorSpec generateSpec(ConnectorContext connectorContext, ConnectorSpecRequest connectorSpecRequest)
     throws IOException {
-    AribaServices aribaServices = new AribaServices(config);
     try {
       accessToken = aribaServices.getAccessToken();
     } catch (AribaException e) {
@@ -155,7 +161,6 @@ public class AribaConnector implements DirectConnector {
    * returns the list of all the templates present in Ariba.
    */
   private JsonArray listTemplates(String pageToken, JsonArray jsonElements) throws IOException {
-    AribaServices aribaServices = new AribaServices(config);
     try {
       accessToken = aribaServices.getAccessToken();
     } catch (AribaException e) {
@@ -188,7 +193,6 @@ public class AribaConnector implements DirectConnector {
 
   private List<StructuredRecord> listTemplateData(String templateName)
     throws IOException, AribaException, InterruptedException {
-    AribaServices aribaServices = new AribaServices(config);
     try {
       accessToken = aribaServices.getAccessToken();
     } catch (AribaException e) {

--- a/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/connector/AribaConnectorConfig.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.ariba.source.AribaServices;
+import io.cdap.plugin.ariba.source.config.AribaPluginConfig;
 import io.cdap.plugin.ariba.source.exception.AribaException;
 import io.cdap.plugin.ariba.source.metadata.AribaResponseContainer;
 import io.cdap.plugin.ariba.source.util.AribaUtil;
@@ -154,7 +155,13 @@ public class AribaConnectorConfig extends PluginConfig {
   }
 
   public final void validateToken(FailureCollector collector) {
-    AribaServices aribaServices = new AribaServices(this);
+    AribaServices aribaServices = new AribaServices(this,
+      AribaPluginConfig.DEFAULT_MAX_RETRY_COUNT,
+      AribaPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
+      AribaPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS,
+      AribaPluginConfig.DEFAULT_RETRY_MULTIPLIER,
+      false);
+
     try {
       String accessToken = aribaServices.getAccessToken();
       URL viewTemplatesURL = HttpUrl.parse(this.getBaseURL()).

--- a/src/main/java/io/cdap/plugin/ariba/source/exception/AribaRetryableException.java
+++ b/src/main/java/io/cdap/plugin/ariba/source/exception/AribaRetryableException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.ariba.source.exception;
+
+/**
+ * This {@code AribaRetryableException} class is used to capture all the errors that are related to Ariba
+ * API limit issues.
+ */
+
+public class AribaRetryableException extends Exception {
+
+  private final Integer errorCode;
+
+  public AribaRetryableException(String message) {
+    this(message, null, null);
+  }
+
+  public AribaRetryableException(String message, Integer errorCode) {
+    this(message, errorCode, null);
+  }
+
+  public AribaRetryableException(String message, Throwable cause) {
+    this(message, null, cause);
+  }
+
+  public AribaRetryableException(String message, Integer errorCode, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  public Integer getErrorCode() {
+    return this.errorCode;
+  }
+}

--- a/src/test/java/io/cdap/plugin/ariba/source/AribaInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/ariba/source/AribaInputFormatTest.java
@@ -26,6 +26,7 @@ import mockit.Mocked;
 import mockit.Tested;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -52,18 +53,32 @@ public class AribaInputFormatTest {
   @Tested
   private AribaInputFormat aribaInputFormat;
 
+  private AribaPluginConfig pluginConfig;
+
+  @Before
+  public void setup() {
+    AribaPluginConfig.Builder pluginConfigBuilder = new AribaPluginConfig.Builder()
+      .referenceName("unit-test-ref-name")
+      .baseURL("https://openapi.ariba.com")
+      .systemType("prod")
+      .realm("test-realm")
+      .viewTemplateName("SourcingProjectFactSystemView")
+      .clientId("client-id")
+      .clientSecret("client-secret")
+      .apiKey("api-key")
+      .tokenURL("https://api.token.ariba.com")
+      .fromDate("2022-01-28T10:05:02Z")
+      .toDate("2022-01-31T10:05:02Z")
+      .initialRetryDuration(AribaPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .maxRetryDuration(AribaPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .retryMultiplier(AribaPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .maxRetryCount(AribaPluginConfig.DEFAULT_MAX_RETRY_COUNT);
+
+    pluginConfig = pluginConfigBuilder.build();
+  }
+
   @Test
   public void testCreateRecordReader() throws IOException, AribaException, InterruptedException {
-    AribaPluginConfig pluginConfig = new AribaPluginConfig("unit-test-ref-name",
-                                                           "https://openapi.au.cloud.ariba.com",
-                                                           "prod",
-                                                           "CloudsufiDSAPP-T",
-                                                           "SourcingProjectFactSystemView",
-                                                           "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                                           "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds",
-                                                           "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                                           "https://api.au.cloud.ariba.com",
-                                                           "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
     aribaInputFormat = new AribaInputFormat();
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode createJob = objectMapper.readTree(createJobResponse);
@@ -90,16 +105,6 @@ public class AribaInputFormatTest {
 
   @Test
   public void testCreateJobThrowError() throws IOException, AribaException, InterruptedException {
-    AribaPluginConfig pluginConfig = new AribaPluginConfig("unit-test-ref-name",
-                                                           "https://openapi.au.cloud.ariba.com",
-                                                           "prod",
-                                                           "CloudsufiDSAPP-T",
-                                                           "SourcingProjectFactSystemView",
-                                                           "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                                           "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds",
-                                                           "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                                           "https://api.au.cloud.ariba.com",
-                                                           "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
     aribaInputFormat = new AribaInputFormat();
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode jobData = objectMapper.readTree(createJobResponse1);
@@ -128,16 +133,6 @@ public class AribaInputFormatTest {
 
   @Test
   public void testCreateJobThrowError1() throws IOException, AribaException, InterruptedException {
-    AribaPluginConfig pluginConfig = new AribaPluginConfig("unit-test-ref-name",
-                                                           "https://openapi.au.cloud.ariba.com",
-                                                           "prod",
-                                                           "CloudsufiDSAPP-T",
-                                                           "SourcingProjectFactSystemView",
-                                                           "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                                           "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds",
-                                                           "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                                           "https://api.au.cloud.ariba.com",
-                                                           "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
     aribaInputFormat = new AribaInputFormat();
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode crateJob = objectMapper.readTree(createJobResponse);
@@ -167,16 +162,6 @@ public class AribaInputFormatTest {
 
   @Test
   public void testCreateJobThrowError3() throws IOException, AribaException, InterruptedException {
-    AribaPluginConfig pluginConfig = new AribaPluginConfig("unit-test-ref-name",
-                                                           "https://openapi.au.cloud.ariba.com",
-                                                           "prod",
-                                                           "CloudsufiDSAPP-T",
-                                                           "SourcingProjectFactSystemView",
-                                                           "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                                           "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds",
-                                                           "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                                           "https://api.au.cloud.ariba.com",
-                                                           "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
     aribaInputFormat = new AribaInputFormat();
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode jobData = objectMapper.readTree(createJobResponse1);
@@ -205,16 +190,6 @@ public class AribaInputFormatTest {
 
   @Test
   public void testCreateJobThrowError4() throws IOException, AribaException, InterruptedException {
-    AribaPluginConfig pluginConfig = new AribaPluginConfig("unit-test-ref-name",
-                                                           "https://openapi.au.cloud.ariba.com",
-                                                           "prod",
-                                                           "CloudsufiDSAPP-T",
-                                                           "SourcingProjectFactSystemView",
-                                                           "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                                           "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds",
-                                                           "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                                           "https://api.au.cloud.ariba.com",
-                                                           "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
     aribaInputFormat = new AribaInputFormat();
     ObjectMapper objectMapper = new ObjectMapper();
     JsonNode crateJob = objectMapper.readTree(createJobResponse);

--- a/src/test/java/io/cdap/plugin/ariba/source/AribaRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/ariba/source/AribaRecordReaderTest.java
@@ -19,14 +19,12 @@ package io.cdap.plugin.ariba.source;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cdap.cdap.api.data.format.StructuredRecord;
-import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.plugin.ariba.source.config.AribaPluginConfig;
 import io.cdap.plugin.ariba.source.exception.AribaException;
 import mockit.Expectations;
 import mockit.Mocked;
-import org.apache.hadoop.io.NullWritable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,17 +44,33 @@ public class AribaRecordReaderTest {
   @Before
   public void setUp() {
     pipelineConfigurer = new MockPipelineConfigurer(null);
-    pluginConfig = new AribaPluginConfig("unit-test-ref-name", "https://openapi.au.cloud.ariba.com",
-                                         "prod", "CloudsufiDSAPP-T",
-                                         "SourcingProjectFactSystemView", "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                         "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds", "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                         "https://api.au.cloud.ariba.com",
-                                         "2022-01-28T10:05:02Z", "2022-01-31T10:05:02Z");
+    AribaPluginConfig.Builder pluginConfigBuilder = new AribaPluginConfig.Builder()
+      .referenceName("unit-test-ref-name")
+      .baseURL("https://openapi.ariba.com")
+      .systemType("prod")
+      .realm("test-realm")
+      .viewTemplateName("SourcingProjectFactSystemView")
+      .clientId("client-id")
+      .clientSecret("client-secret")
+      .apiKey("api-key")
+      .tokenURL("https://api.token.ariba.com")
+      .fromDate("2022-01-28T10:05:02Z")
+      .toDate("2022-01-31T10:05:02Z")
+      .initialRetryDuration(AribaPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .maxRetryDuration(AribaPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .retryMultiplier(AribaPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .maxRetryCount(AribaPluginConfig.DEFAULT_MAX_RETRY_COUNT);
+    pluginConfig = pluginConfigBuilder.build();
+
+    aribaServices = new AribaServices(pluginConfig.getConnection(),
+      pluginConfig.getMaxRetryCount(),
+      pluginConfig.getInitialRetryDuration(),
+      pluginConfig.getMaxRetryDuration(),
+      pluginConfig.getRetryMultiplier(), false);
   }
 
   @Test
   public void testInitialize() throws IOException, AribaException, InterruptedException {
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     AribaRecordReader aribaRecordReader = new AribaRecordReader(aribaServices, getPluginSchema(), pluginConfig);
     AribaInputSplit aribaInputSplit = new AribaInputSplit("sourceView.zip", "3343ddsfsg3434");
     AribaStructuredTransformer aribaStructuredTransformer = new AribaStructuredTransformer();
@@ -85,7 +99,6 @@ public class AribaRecordReaderTest {
   @Test
   public void testNextKeyValueFalse(@Mocked AribaInputSplit aribaInputSplit,
                                     @Mocked JsonNode node) throws IOException, AribaException, InterruptedException {
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     AribaRecordReader aribaRecordReader = new AribaRecordReader(aribaServices, pipelineConfigurer.getOutputSchema(),
                                                                 pluginConfig);
     new Expectations(AribaServices.class) {
@@ -113,7 +126,6 @@ public class AribaRecordReaderTest {
 
   @Test(expected = IOException.class)
   public void testInitializeError() throws IOException, InterruptedException, AribaException {
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     AribaRecordReader aribaRecordReader = new AribaRecordReader(aribaServices, pipelineConfigurer.getOutputSchema(),
                                                                 pluginConfig);
     AribaInputSplit aribaInputSplit = new AribaInputSplit("sourceView.zip", "3343ddsfsg3434");
@@ -154,191 +166,191 @@ public class AribaRecordReaderTest {
     "\":{\"EventType\":\"\"},\"SourceSystem\":{\"SourceSystemId\":\"ASM\"}}";
 
   public static Schema getPluginSchema() throws IOException {
-    String schemaString = "{\n" +
-      "   \"type\":\"record\",\n" +
-      "   \"name\":\"AribaColumnMetadata\",\n" +
-      "   \"fields\":[\n" +
-      "      {\n" +
-      "         \"name\":\"IsTestProject\",\n" +
-      "         \"type\":[\n" +
-      "            \"boolean\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Origin\",\n" +
-      "         \"type\":[\n" +
-      "            \"double\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Status\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Description\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"OnTimeOrLate\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ProcessStatus\",\n" +
-      "         \"type\":[\n" +
-      "            \"bytes\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"TargetSavingsPct\",\n" +
-      "         \"type\":[\n" +
-      "            \"double\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"LoadUpdateTime\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"AclId\",\n" +
-      "         \"type\":[\n" +
-      "            \"int\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ProjectId\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Duration\",\n" +
-      "         \"type\":[\n" +
-      "            \"double\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ProjectReason\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"BaselineSpend\",\n" +
-      "         \"type\":[\n" +
-      "            \"long\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ResultsDescription\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"SourcingMechanism\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"AwardJustification\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"LoadCreateTime\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ContractMonths\",\n" +
-      "         \"type\":[\n" +
-      "            \"double\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ActualSaving\",\n" +
-      "         \"type\":[\n" +
-      "            \"double\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"State\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Currency\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"ExecutionStrategy\",\n" +
-      "         \"type\":[\n" +
-      "            \"string\",\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      },\n" +
-      "      {\n" +
-      "         \"name\":\"Owner\",\n" +
-      "         \"type\":[\n" +
-      "            {\n" +
-      "               \"type\":\"record\",\n" +
-      "               \"name\":\"Owner\",\n" +
-      "               \"fields\":[\n" +
-      "                  {\n" +
-      "                     \"name\":\"UserId\",\n" +
-      "                     \"type\":[\n" +
-      "                        \"string\",\n" +
-      "                        \"null\"\n" +
-      "                     ]\n" +
-      "                  },\n" +
-      "                  {\n" +
-      "                     \"name\":\"SourceSystem\",\n" +
-      "                     \"type\":[\n" +
-      "                        \"string\",\n" +
-      "                        \"null\"\n" +
-      "                     ]\n" +
-      "                  }\n" +
-      "               ]\n" +
-      "            },\n" +
-      "            \"null\"\n" +
-      "         ]\n" +
-      "      }\n" +
-      "   ]\n" +
+    String schemaString = "{" +
+      "   \"type\":\"record\"," +
+      "   \"name\":\"AribaColumnMetadata\"," +
+      "   \"fields\":[" +
+      "      {" +
+      "         \"name\":\"IsTestProject\"," +
+      "         \"type\":[" +
+      "            \"boolean\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Origin\"," +
+      "         \"type\":[" +
+      "            \"double\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Status\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Description\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"OnTimeOrLate\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ProcessStatus\"," +
+      "         \"type\":[" +
+      "            \"bytes\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"TargetSavingsPct\"," +
+      "         \"type\":[" +
+      "            \"double\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"LoadUpdateTime\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"AclId\"," +
+      "         \"type\":[" +
+      "            \"int\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ProjectId\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Duration\"," +
+      "         \"type\":[" +
+      "            \"double\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ProjectReason\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"BaselineSpend\"," +
+      "         \"type\":[" +
+      "            \"long\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ResultsDescription\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"SourcingMechanism\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"AwardJustification\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"LoadCreateTime\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ContractMonths\"," +
+      "         \"type\":[" +
+      "            \"double\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ActualSaving\"," +
+      "         \"type\":[" +
+      "            \"double\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"State\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Currency\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"ExecutionStrategy\"," +
+      "         \"type\":[" +
+      "            \"string\"," +
+      "            \"null\"" +
+      "         ]" +
+      "      }," +
+      "      {" +
+      "         \"name\":\"Owner\"," +
+      "         \"type\":[" +
+      "            {" +
+      "               \"type\":\"record\"," +
+      "               \"name\":\"Owner\"," +
+      "               \"fields\":[" +
+      "                  {" +
+      "                     \"name\":\"UserId\"," +
+      "                     \"type\":[" +
+      "                        \"string\"," +
+      "                        \"null\"" +
+      "                     ]" +
+      "                  }," +
+      "                  {" +
+      "                     \"name\":\"SourceSystem\"," +
+      "                     \"type\":[" +
+      "                        \"string\"," +
+      "                        \"null\"" +
+      "                     ]" +
+      "                  }" +
+      "               ]" +
+      "            }," +
+      "            \"null\"" +
+      "         ]" +
+      "      }" +
+      "   ]" +
       "}";
 
     return Schema.parseJson(schemaString);

--- a/src/test/java/io/cdap/plugin/ariba/source/metadata/proto/PropertiesTest.java
+++ b/src/test/java/io/cdap/plugin/ariba/source/metadata/proto/PropertiesTest.java
@@ -70,95 +70,95 @@ public class PropertiesTest {
   AribaResponseContainer response;
   SampleRequest sampleRequest;
 
-  String jsonNode = "{\n" +
-    "  \"type\": \"object\",\n" +
-    "  \"access_token\": \"jiuokiopu\",\n" +
-    "  \"status\": \"completed\",\n" +
-    "  \"totalNumOfPages\": \"1\",\n" +
-    "  \"currentPageNum\": \"1\",\n" +
-    "  \"message\": \"test\",\n" +
-    "  \"properties\": {\n" +
-    "    \"IsTestProject\": {\n" +
-    "      \"title\": \"IsTestProject\",\n" +
-    "      \"type\": [\n" +
-    "        \"boolean\",\n" +
-    "        \"null\"\n" +
-    "      ],\n" +
-    "      \"precision\": null,\n" +
-    "      \"scale\": null,\n" +
-    "      \"size\": null,\n" +
-    "      \"allowedValues\": null\n" +
-    "    },\n" +
-    "   \"Owner\": {\n" +
-    "      \"type\": [\n" +
-    "        \"object\",\n" +
-    "        \"null\"\n" +
-    "      ],\n" +
-    "      \"properties\": {\n" +
-    "        \"SourceSystem\": {\n" +
-    "          \"title\": \"Owner.SourceSystem\",\n" +
-    "          \"type\": [\n" +
-    "            \"string\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \"precision\": null,\n" +
-    "          \"scale\": null,\n" +
-    "          \"size\": 100,\n" +
-    "          \"allowedValues\": null\n" +
-    "        },\n" +
-    "        \"UserId\": {\n" +
-    "          \"title\": \"Owner.UserId\",\n" +
-    "          \"type\": [\n" +
-    "            \"string\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \"precision\": null,\n" +
-    "          \"scale\": null,\n" +
-    "          \"size\": 50,\n" +
-    "          \"allowedValues\": null\n" +
-    "        }\n" +
-    "      }\n" +
-    "    },\n" +
-    "     \"Organization\": {\n" +
-    "      \"type\": [\n" +
-    "        \"array\",\n" +
-    "        \"null\"\n" +
-    "      ],\n" +
-    "      \"items\": [\n" +
-    "        {\n" +
-    "          \"type\": [\n" +
-    "            \"object\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \"properties\": {}\n" +
-    "        },\n" +
-    "         {\n" +
-    "          \"type\": [\n" +
-    "            \"array\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \n" +
-    "  \"items\": [\n" +
-    "        {\n" +
-    "          \"type\": [\n" +
-    "            \"object\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \"properties\": {}\n" +
-    "        },\n" +
-    "        {\n" +
-    "          \"type\": [\n" +
-    "            \"array\",\n" +
-    "            \"null\"\n" +
-    "          ],\n" +
-    "          \"properties\": {}\n" +
-    "        }\n" +
-    "      ]\n" +
-    "        }\n" +
-    "        \n" +
-    "      ]\n" +
-    "    }\n" +
-    "  }\n" +
+  String jsonNode = "{" +
+    "  \"type\": \"object\"," +
+    "  \"access_token\": \"jiuokiopu\"," +
+    "  \"status\": \"completed\"," +
+    "  \"totalNumOfPages\": \"1\"," +
+    "  \"currentPageNum\": \"1\"," +
+    "  \"message\": \"test\"," +
+    "  \"properties\": {" +
+    "    \"IsTestProject\": {" +
+    "      \"title\": \"IsTestProject\"," +
+    "      \"type\": [" +
+    "        \"boolean\"," +
+    "        \"null\"" +
+    "      ]," +
+    "      \"precision\": null," +
+    "      \"scale\": null," +
+    "      \"size\": null," +
+    "      \"allowedValues\": null" +
+    "    }," +
+    "   \"Owner\": {" +
+    "      \"type\": [" +
+    "        \"object\"," +
+    "        \"null\"" +
+    "      ]," +
+    "      \"properties\": {" +
+    "        \"SourceSystem\": {" +
+    "          \"title\": \"Owner.SourceSystem\"," +
+    "          \"type\": [" +
+    "            \"string\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          \"precision\": null," +
+    "          \"scale\": null," +
+    "          \"size\": 100," +
+    "          \"allowedValues\": null" +
+    "        }," +
+    "        \"UserId\": {" +
+    "          \"title\": \"Owner.UserId\"," +
+    "          \"type\": [" +
+    "            \"string\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          \"precision\": null," +
+    "          \"scale\": null," +
+    "          \"size\": 50," +
+    "          \"allowedValues\": null" +
+    "        }" +
+    "      }" +
+    "    }," +
+    "     \"Organization\": {" +
+    "      \"type\": [" +
+    "        \"array\"," +
+    "        \"null\"" +
+    "      ]," +
+    "      \"items\": [" +
+    "        {" +
+    "          \"type\": [" +
+    "            \"object\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          \"properties\": {}" +
+    "        }," +
+    "         {" +
+    "          \"type\": [" +
+    "            \"array\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          " +
+    "  \"items\": [" +
+    "        {" +
+    "          \"type\": [" +
+    "            \"object\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          \"properties\": {}" +
+    "        }," +
+    "        {" +
+    "          \"type\": [" +
+    "            \"array\"," +
+    "            \"null\"" +
+    "          ]," +
+    "          \"properties\": {}" +
+    "        }" +
+    "      ]" +
+    "        }" +
+    "        " +
+    "      ]" +
+    "    }" +
+    "  }" +
     "}";
 
   private AribaPluginConfig pluginConfig;
@@ -170,12 +170,29 @@ public class PropertiesTest {
   @Before
   public void setUp() {
     properties = new Properties();
-    pluginConfig = new AribaPluginConfig("unit-test-ref-name", "https://openapi.au.cloud.ariba.com",
-                                         "prod", "CloudsufiDSAPP-T",
-                                         "SourcingProjectFactSystemView", "08ee0299-4849-42a4-8464-3abed75fc74e",
-                                         "c3B5wvrEsjKucFGlGhKSWUDqDRGE2Wds", "xryi0757SU8pEyk7ePc7grc7vgDXdz8O",
-                                         "https://api.au.cloud.ariba.com", "2022-01-28T10:05:02Z",
-                                          "2022-01-31T10:05:02Z");
+    AribaPluginConfig.Builder pluginConfigBuilder = new AribaPluginConfig.Builder()
+      .referenceName("unit-test-ref-name")
+      .baseURL("https://openapi.ariba.com")
+      .systemType("prod")
+      .realm("test-realm")
+      .viewTemplateName("SourcingProjectFactSystemView")
+      .clientId("client-id")
+      .clientSecret("client-secret")
+      .apiKey("api-key")
+      .tokenURL("https://api.token.ariba.com")
+      .fromDate("2022-01-28T10:05:02Z")
+      .toDate("2022-01-31T10:05:02Z")
+      .initialRetryDuration(AribaPluginConfig.DEFAULT_INITIAL_RETRY_DURATION_SECONDS)
+      .maxRetryDuration(AribaPluginConfig.DEFAULT_MAX_RETRY_DURATION_SECONDS)
+      .retryMultiplier(AribaPluginConfig.DEFAULT_RETRY_MULTIPLIER)
+      .maxRetryCount(AribaPluginConfig.DEFAULT_MAX_RETRY_COUNT);
+    pluginConfig = pluginConfigBuilder.build();
+
+    aribaServices = new AribaServices(pluginConfig.getConnection(),
+      pluginConfig.getMaxRetryCount(),
+      pluginConfig.getInitialRetryDuration(),
+      pluginConfig.getMaxRetryDuration(),
+      pluginConfig.getRetryMultiplier(), false);
   }
 
   @Test
@@ -263,7 +280,6 @@ public class PropertiesTest {
   public void testValidateToken() throws AribaException, IOException {
     MockFailureCollector collector = new MockFailureCollector();
     AribaConnectorConfig connectorConfig = pluginConfig.getConnection();
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     okHttpClient = new OkHttpClient();
     Request mockRequest = new Request.Builder().url("https://some-url.com").build();
     res = new Response.Builder()
@@ -294,7 +310,6 @@ public class PropertiesTest {
   public void testValidateTokenWithInvalidResponse() throws AribaException, IOException {
     MockFailureCollector collector = new MockFailureCollector();
     AribaConnectorConfig connectorConfig = pluginConfig.getConnection();
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     new Expectations(AribaServices.class) {
       {
         aribaServices.getAccessToken();
@@ -304,6 +319,7 @@ public class PropertiesTest {
     };
     connectorConfig.validateToken(collector);
     Assert.assertEquals(1, collector.getValidationFailures().size());
+    System.out.println(collector.getValidationFailures().get(0).getMessage());
   }
 
   private void testTest(AribaConnector connector) {
@@ -328,7 +344,6 @@ public class PropertiesTest {
 
   private void testGenerateSpec(AribaConnector connector) throws IOException, AribaException, InterruptedException {
 
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     URL url = null;
     InputStream inputStream = new ByteArrayInputStream(jsonNode.getBytes());
     new Expectations(AribaServices.class) {
@@ -358,7 +373,6 @@ public class PropertiesTest {
     AribaColumnMetadata columnList = columnDetail.build();
     List<AribaColumnMetadata> columnDetails = new ArrayList<>();
     columnDetails.add(columnList);
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     new Expectations(AribaServices.class) {
       {
         aribaServices.getMetadata(anyString, anyString);
@@ -390,7 +404,6 @@ public class PropertiesTest {
   @Test
   public void testSample() throws AribaException, IOException, InterruptedException {
     AribaConnector aribaConnector = new AribaConnector(pluginConfig.getConnection());
-    aribaServices = new AribaServices(pluginConfig.getConnection());
     sampleRequest = SampleRequest.builder(1).build();
     URL url = null;
     InputStream inputStream = new ByteArrayInputStream(jsonNode.getBytes());
@@ -412,6 +425,10 @@ public class PropertiesTest {
         result = "testToken";
         minTimes = 0;
 
+        aribaServices.isApiLimitExhausted((Response) any);
+        result = false;
+        minTimes = 0;
+
         sampleRequest.getPath();
         result = "requisitionLineItemView";
         minTimes = 0;
@@ -421,7 +438,4 @@ public class PropertiesTest {
     Assert.assertTrue(aribaConnector.sample(new MockConnectorContext(new MockConnectorConfigurer()), sampleRequest).
       isEmpty());
   }
-
-  }
-
-
+}

--- a/widgets/Ariba-batchsource.json
+++ b/widgets/Ariba-batchsource.json
@@ -152,6 +152,42 @@
           "widget-attributes": {
             "placeholder": "End date of the extraction, for example, 2022-03-29T00:00:00Z."
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Initial Retry Duration (Seconds)",
+          "name": "initialRetryDuration",
+          "widget-attributes": {
+            "default": "2",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Duration (Seconds)",
+          "name": "maxRetryDuration",
+          "widget-attributes": {
+            "default": "300",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Count",
+          "name": "maxRetryCount",
+          "widget-attributes": {
+            "default": "3",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Retry Multiplier",
+          "name": "retryMultiplier",
+          "widget-attributes": {
+            "default": "2",
+            "placeholder": "The multiplier to use on retry attempts."
+          }
         }
       ]
     }


### PR DESCRIPTION
[Cherrypick] 
Commit : 9358fe5c6013c074c4321a0a01a96e42610f813d
PR: https://github.com/data-integrations/ariba-plugins/pull/27

---

## Add Retry with dev.failsafe

Jira : [PLUGIN-1754](https://cdap.atlassian.net/browse/PLUGIN-1754)

### Description

When API Fails or rate limited, we want to retry after some wait, this PR adds `dev.failsafe` to handle the retry !
This is done by throwing a custom exception if the error is retryable.

### UI Field

- Modified `Ariba-batchsource.json`

### Docs

- No Changes made to docs.
  - The UI fields are maked hidden and does not require a change in docs.

### Code change

- Added `AribaRetryableException.java`
  -  Custom exception class if thrown the method will be retried. 
- Modified `AribaBatchSource.java`
- Modified `AribaInputFormat.java`
- Modified `AribaServices.java`
- Modified `AribaPluginConfig.java`
- Modified `AribaConnector.java`
- Modified `AribaConnectorConfig.java`

### Unit Tests

- Modified `AribaBatchSourceTest.java`
- Modified `AribaInputFormatTest.java`
- Modified `AribaRecordReaderTest.java`
- Modified `AribaServicesTest.java`
- Modified `PropertiesTest.java`


[PLUGIN-1754]: https://cdap.atlassian.net/browse/PLUGIN-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ